### PR TITLE
Add tags in API

### DIFF
--- a/src/models/indicator.types.ts
+++ b/src/models/indicator.types.ts
@@ -22,7 +22,7 @@ export interface FeatureProperties {
   nombre_valeurs?: number;
   granularite?: string;
   sources?: string;
-  tags?: string | null;
+  tags?: Array<string> | null;
   is_public?: boolean;
   commentaires?: string | null;
 }

--- a/src/services/geoweb.service.ts
+++ b/src/services/geoweb.service.ts
@@ -6,8 +6,12 @@ const GEO2FRANCE_BASE_REQUEST =
   'https://www.geo2france.fr/geoserver/odema/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json';
 class GeoWebService {
   async getFilteredIndicatorsProperties(): Promise<Indicator[]> {
-    const url = `${GEO2FRANCE_BASE_REQUEST}&TYPENAMES=odema:ind_ref_dev&PROPERTYNAME=guid,nom_indicateur`;
-    const response = await axios.get(url);
+    const url = `${GEO2FRANCE_BASE_REQUEST}&TYPENAMES=odema:ind_ref_dev&PROPERTYNAME=guid,nom_indicateur,tags`;
+    let response = await axios.get(url);
+    response.data.features.forEach((feature) => {
+        feature.properties.tags = feature.properties.tags.split('|')
+    });
+    console.log(response.data);
     return response.data;
   }
   async getMatrixForIndicator({


### PR DESCRIPTION
Ajout de la properties "tags".
L'API renvoi les tags sous forme de`string` (séparés par des "|"). Le service _geowebservice_ transforme la chaîne de caractères en `Array<string>` directement utilisable.